### PR TITLE
Put command descriptions directly inside keymaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - When (re)loading keys/signals, if the key/signal file is already open in a
   buffer, preserve the position of point
+- Support `which-key` remapping for minor-modes and evil states, by putting
+  descriptions inside the keymaps
 
 ## Changed
 

--- a/corkey.el
+++ b/corkey.el
@@ -207,13 +207,13 @@ When the optional DESCRIPTION is provided then we set up
         (kbd keys)
         target))
      ((eq 'default mode-sym)
-      (evil-define-minor-mode-key state 'corkey-local-mode (kbd keys) target))
+      (evil-define-minor-mode-key state 'corkey-local-mode (kbd keys) (if description
+                                                                          (cons description target)
+                                                                        target)))
      (t
-      (evil-define-minor-mode-key state mode-var (kbd keys) target))))
-  (when description
-    (if (eq 'default mode-sym)
-        (which-key-add-key-based-replacements keys description)
-      (which-key-add-major-mode-key-based-replacements mode-sym keys description))))
+      (evil-define-minor-mode-key state mode-var (kbd keys) (if description
+                                                                (cons description target)
+                                                              target))))))
 
 (defun corgi/fix-keymap-precedence ()
   "Move `corkey-local-mode' bindings to the end of


### PR DESCRIPTION
This means which-key needs to do less work (no handling of "replacements"), and
that it generally "just works", including for derived major modes, minor modes,
and evil states.